### PR TITLE
Update the user to be me in the Metrics

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.METRICS_TOKEN }}
 
           # Options
-          user: github-actions[bot]
+          user: outmaneuver
           template: classic
           base: header, activity, community, repositories, metadata
           base_hireable: yes


### PR DESCRIPTION
Update the `user` field in the `.github/workflows/metrics.yml` file to reflect the user as "outmaneuver".

* Change the `user` field from `github-actions[bot]` to `outmaneuver` in the `.github/workflows/metrics.yml` file

